### PR TITLE
Stub of release workflow to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,109 @@
+name: Publish
+
+on:
+#   release:
+#     types: [published]
+
+  workflow_dispatch:
+    inputs:
+        tag_name:
+          description: "Tag name to simulate the release version"
+          required: true
+          type: string
+  
+jobs:
+  publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.64.0
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Rust version of rtactor
+        id: rust-version
+        run: |
+          echo "app_version=$(head -6 Cargo.toml | grep version | sed 's/"/ /g' | awk '{print $3}')" >> $GITHUB_OUTPUT
+
+      - name: Rust version of rtactor-macros
+        id: rust-version-macros
+        run: |
+          echo "app_version=$(head -6 rtactor-macros/Cargo.toml | grep version | sed 's/"/ /g' | awk '{print $3}')" >> $GITHUB_OUTPUT
+
+      - name: Expected version
+        run: |
+          EXPECTED_VERSION="${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.event.release.tag_name }}"
+          echo "EXPECTED_VERSION=${TAG#v}" >> $GITHUB_ENV
+
+      - name: Display versions
+        run: |
+          echo "rtactor version: '${{ steps.rust-version.outputs.app_version }}'"
+          echo "rtactor-macros version: '${{ steps.rust-version-macros.outputs.app_version }}'"
+          echo "Expected version: '$EXPECTED_VERSION'"
+
+      - name: Validate that the crates versions matches the release TAG
+        run: |
+          if [[ "${{ steps.rust-version.outputs.app_version }}" != "$EXPECTED_VERSION" ]]; then
+            echo "rtactor version mismatch: ${{ steps.rust-version.outputs.app_version }} != $EXPECTED_VERSION"
+            exit 1
+          fi
+          if [[ "${{ steps.rust-version-macros.outputs.app_version }}" != "$EXPECTED_VERSION" ]]; then
+            echo "rtactor version mismatch: ${{ steps.rust-version.outputs.app_version }} != $EXPECTED_VERSION"
+            exit 1
+          fi
+
+      - name: Test publish rtactor
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          # Ensure the Cargo registry token is available
+          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+            echo "Error: CARGO_REGISTRY_TOKEN is not set" >&2
+            exit 1
+          fi
+
+          # Test publishing the crate to crates.io
+          cargo publish --dry-run
+
+      - name: Test publish rtactor
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          # Ensure the Cargo registry token is available
+          if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+            echo "Error: CARGO_REGISTRY_TOKEN is not set" >&2
+            exit 1
+          fi
+
+          # Test publishing the crate to crates.io
+          cd rtactor-macros && cargo publish --dry-run
+  
+    #   - name: Publish to crates.io
+    #     env:
+    #       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    #     run: |
+    #       # Ensure the Cargo registry token is available
+    #       if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+    #         echo "Error: CARGO_REGISTRY_TOKEN is not set" >&2
+    #         exit 1
+    #       fi
+
+    #       # Publish the crate to crates.io
+    #       cargo publish
+
+    #   - name: Publish to crates.io
+    #     env:
+    #       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    #     run: |
+    #       # Ensure the Cargo registry token is available
+    #       if [ -z "$CARGO_REGISTRY_TOKEN" ]; then
+    #         echo "Error: CARGO_REGISTRY_TOKEN is not set" >&2
+    #         exit 1
+    #       fi
+  
+    #       # Publish the crate to crates.io
+    #       cd rtactor-macros && cargo publish


### PR DESCRIPTION
We need this to exist in the default branch (`main`), so that it can be tested in a branch (GitHub web UI will not show workflows that do not exists in the default branch).