### PR TITLE
refactor: add reexported mockall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "rtactor"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "approx",
  "assert2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rtactor"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT"
 description = "An Actor framework specially designed for Real-Time constrained use cases."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,3 +269,8 @@ pub use reactive::Timer;
 
 #[cfg(feature = "mockall")]
 pub use reactive::MockBehavior;
+
+// This crate used in the interface is reexported to allow user to build with the same version.
+// see https://doc.rust-lang.org/rustdoc/write-documentation/re-exports.html
+#[cfg(feature = "mockall")]
+pub use mockall;

--- a/src/reactive.rs
+++ b/src/reactive.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 /// The custom implementation of message handling for a given reactive actor.
 ///
 /// There are two ways to write mocks of reactive actors. There is the very simple
-/// `MockBeavior` that mocks directly this trait. Or a more complex and powerful
+/// `MockBehavior` that mocks directly this trait. Or a more complex and powerful
 /// `simulation::ReactiveMocker` that allows to change the mock during the tests, user
 /// data, etc.
 #[cfg_attr(feature = "mockall", mockall::automock)]


### PR DESCRIPTION
This simplify requirement definition for the user test code.